### PR TITLE
将直接安装二进制文件改为本地编译

### DIFF
--- a/Formula/baidupcs-go.rb
+++ b/Formula/baidupcs-go.rb
@@ -1,11 +1,24 @@
 class BaidupcsGo < Formula
-    desc "仿 Linux shell 文件处理命令的百度网盘命令行客户端"
-    homepage "https://github.com/iikira/BaiduPCS-Go"
-    url "https://github.com/iikira/BaiduPCS-Go/releases/download/v3.5.6/BaiduPCS-Go-v3.5.6-darwin-osx-amd64.zip"
-    version "3.5.6"
-    sha256 "db087e64d606639ca3e05a4b482174a06d3c0eabd6cbdbcc317374fc40742a96"
+  desc "仿 Linux shell 文件处理命令的百度网盘命令行客户端"
+  homepage "https://github.com/iikira/BaiduPCS-Go"
+  version "3.5.6"
+  url "https://github.com/iikira/BaiduPCS-Go/archive/v#{version}.tar.gz"
+  sha256 "0b2abd18c5101d5255faa31c713cbebad3804af07c1a008a5b9b799060beb12a"
 
-    def install
-        bin.install "BaiduPCS-Go"
-    end
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/iikira").mkpath
+    ln_s buildpath, buildpath/"src/github.com/iikira/BaiduPCS-Go"
+    system "go", "get", "github.com/iikira/BaiduPCS-Go"
+
+    bin.install "bin/BaiduPCS-Go"
+
+    bin.install_symlink "BaiduPCS-Go" => "baidupcs"
+  end
+
+  test do
+    system "#{bin}/BaiduPCS-Go", "--version"
+  end
 end


### PR DESCRIPTION
我注意到大佬的项目直接 `bin.install` 了一个已经编译好的二进制文件，这样比较方便，但同时带来了一定的局限性：

- 二进制文件是针对 Mac OS 的环境编译的，因此**无法被 Linuxbrew 使用**
- 不符合 Homebrew 的规范

因此我把它改成了本地编译的模式。这样，Mac OS、Linux 和 Windows (WSL) 上都可以使用 Homebrew 或者 Linuxbrew 安装了。


如果大佬觉得有必要分发二进制文件的话，可以考虑使用 `Bottles`。但 Homebrew 要求 `Bottles` 必须以类似这样的方式打包 (主要是要包含 `bottle` 关键字)：

```
"#{root_url}/#{name}-#{version}.#{tag}.bottle.#{revision}.tar.gz"
```

大佬的 `Releases` 显然不符合要求，所以就没弄。


另外第 18 行创建的软链接是为了在终端中启动 `BaiduPCS-Go` 的时候少打几个字，如果不喜欢可以去掉。

我刚刚开始学习 Homebrew 和 Ruby，**如果有什么不对的地方还请多多指教**